### PR TITLE
Add `mariadb_container_image_v12_2`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,8 @@ mariadb_container_image_v11_4: "{{ mariadb_container_image_registry_prefix }}mar
 mariadb_container_image_v11_8: "{{ mariadb_container_image_registry_prefix }}mariadb:11.8.6"
 mariadb_container_image_v12_0: "{{ mariadb_container_image_registry_prefix }}mariadb:12.0.2"
 mariadb_container_image_v12_1: "{{ mariadb_container_image_registry_prefix }}mariadb:12.1.2"
-mariadb_container_image_latest: "{{ mariadb_container_image_v12_1 }}"
+mariadb_container_image_v12_2: "{{ mariadb_container_image_registry_prefix }}mariadb:12.2.2"
+mariadb_container_image_latest: "{{ mariadb_container_image_v12_2 }}"
 
 # This variable is assigned at runtime. Overriding its value has no effect.
 mariadb_container_image_to_use: "{{ mariadb_container_image_latest }}"

--- a/tasks/detect_existing_version.yml
+++ b/tasks/detect_existing_version.yml
@@ -88,3 +88,8 @@
       ansible.builtin.set_fact:
         mariadb_detected_version_corresponding_container_image: "{{ mariadb_container_image_v12_1 }}"
       when: "mariadb_detected_version.startswith('12.1.')"
+
+    - name: Determine container image corresponding to detected version (use 12.2, if detected)
+      ansible.builtin.set_fact:
+        mariadb_detected_version_corresponding_container_image: "{{ mariadb_container_image_v12_2 }}"
+      when: "mariadb_detected_version.startswith('12.2.')"


### PR DESCRIPTION
12.2 is available: https://hub.docker.com/_/mariadb/tags?name=12.2